### PR TITLE
Revert "Include `routes.agency_id` by default"

### DIFF
--- a/gtfsblocks/gtfs.py
+++ b/gtfsblocks/gtfs.py
@@ -372,7 +372,7 @@ class Feed:
         REQUIRED_COLS = {
             "agency": ["agency_name", "agency_url", "agency_timezone"],
             "trips": ["trip_id", "route_id", "service_id", "block_id", "shape_id"],
-            "routes": ["route_id", "agency_id", "route_short_name", "route_type"],
+            "routes": ["route_id", "route_short_name", "route_type"],
             "calendar": [
                 "service_id",
                 "monday",
@@ -936,7 +936,6 @@ class Feed:
                 service_add["weekday"] = service_add["date"].dt.dayofweek.apply(
                     lambda x: dow_dict[x]
                 )
-                # TODO: ensure service_add isn't NA or empty. test w/ RIPTA
                 patterns = pd.concat([patterns, service_add], ignore_index=True)
 
             # Remove service IDs based on calendar_dates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gtfsblocks"
-version = "0.1.4"
+version = "0.1.3"
 authors = [
   { name="Dan McCabe", email="Dan.McCabe@nlr.gov" },
 ]


### PR DESCRIPTION
Reverts dan-mccabe/gtfsblocks#9. Existing code was correct (agency_id is included as long as it is present, but it's not required to be present for feeds with only one agency)